### PR TITLE
kotlin-client-custom-serializer-for-integer-enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -18,10 +18,23 @@ import kotlinx.serialization.Serializable
 {{#enumUnknownDefaultCase}}
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
+{{^isString}}
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+{{/isString}}
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 {{/enumUnknownDefaultCase}}
+{{^enumUnknownDefaultCase}}{{^isString}}
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+{{/isString}}{{/enumUnknownDefaultCase}}
 {{/kotlinx_serialization}}
 {{/multiplatform}}
 {{#multiplatform}}
@@ -33,7 +46,7 @@ import kotlinx.serialization.*
  *
  * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
  */
-{{#multiplatform}}@Serializable{{/multiplatform}}{{#kotlinx_serialization}}@Serializable{{#enumUnknownDefaultCase}}(with = {{classname}}Serializer::class){{/enumUnknownDefaultCase}}{{/kotlinx_serialization}}
+{{#multiplatform}}@Serializable{{/multiplatform}}{{#kotlinx_serialization}}@Serializable{{#enumUnknownDefaultCase}}(with = {{classname}}Serializer::class){{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}{{^isString}}(with = {{classname}}Serializer::class){{/isString}}{{/enumUnknownDefaultCase}}{{/kotlinx_serialization}}
 {{^multiplatform}}
 {{#moshi}}
 @JsonClass(generateAdapter = false)
@@ -51,9 +64,9 @@ import kotlinx.serialization.*
     {{#jackson}}
     @JsonProperty(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}}){{#enumUnknownDefaultCase}}{{#-last}} @JsonEnumDefaultValue{{/-last}}{{/enumUnknownDefaultCase}}
     {{/jackson}}
-    {{#kotlinx_serialization}}
+    {{#kotlinx_serialization}}{{^isString}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
-    {{/kotlinx_serialization}}
+    {{/isString}}{{/kotlinx_serialization}}
     {{/multiplatform}}
     {{#multiplatform}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
@@ -95,18 +108,40 @@ import kotlinx.serialization.*
           }
         }
     }
-}{{#kotlinx_serialization}}{{#enumUnknownDefaultCase}}
-
+}
+{{#kotlinx_serialization}}{{#enumUnknownDefaultCase}}
 internal object {{classname}}Serializer : KSerializer<{{classname}}> {
-    override val descriptor = {{{dataType}}}.serializer().descriptor
+    override val descriptor = {{dataType}}.serializer().descriptor
 
     override fun deserialize(decoder: Decoder): {{classname}} {
         val value = decoder.decodeSerializableValue({{{dataType}}}.serializer())
         return {{classname}}.values().firstOrNull { it.value == value }
+            {{#isString}}
             ?: {{classname}}.{{#allowableValues}}{{#enumVars}}{{#-last}}{{&name}}{{/-last}}{{/enumVars}}{{/allowableValues}}
+            {{/isString}}
+            {{^isString}}
+            ?: throw IllegalArgumentException("Unknown enum value: $value")
+            {{/isString}}
     }
 
     override fun serialize(encoder: Encoder, value: {{classname}}) {
         encoder.encodeSerializableValue({{{dataType}}}.serializer(), value.value)
     }
-}{{/enumUnknownDefaultCase}}{{/kotlinx_serialization}}
+}
+{{/enumUnknownDefaultCase}}
+{{^enumUnknownDefaultCase}}{{^isString}}
+internal object {{classname}}Serializer : KSerializer<{{classname}}> {
+    override val descriptor = {{dataType}}.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): {{classname}} {
+        val value = decoder.decodeSerializableValue({{{dataType}}}.serializer())
+        return {{classname}}.values().firstOrNull { it.value == value }
+            ?: throw IllegalArgumentException("Unknown enum value: $value")
+    }
+
+    override fun serialize(encoder: Encoder, value: {{classname}}) {
+        encoder.encodeSerializableValue({{{dataType}}}.serializer(), value.value)
+    }
+}
+{{/isString}}{{/enumUnknownDefaultCase}}
+{{/kotlinx_serialization}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -64,7 +64,7 @@ import kotlinx.serialization.*
     {{#jackson}}
     @JsonProperty(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}}){{#enumUnknownDefaultCase}}{{#-last}} @JsonEnumDefaultValue{{/-last}}{{/enumUnknownDefaultCase}}
     {{/jackson}}
-    {{#kotlinx_serialization}}{{^isString}}
+    {{#kotlinx_serialization}}{{#isString}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
     {{/isString}}{{/kotlinx_serialization}}
     {{/multiplatform}}

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
@@ -29,12 +29,15 @@ import com.squareup.moshi.JsonClass
 enum class ApiStringEnumRef(val value: kotlin.String) {
 
     @Json(name = "success")
+    
     success("success"),
 
     @Json(name = "failure")
+    
     failure("failure"),
 
     @Json(name = "unclassified")
+    
     unclassified("unclassified");
 
     /**

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -28,15 +28,19 @@ import com.fasterxml.jackson.annotation.JsonProperty
 enum class StringEnumRef(val value: kotlin.String) {
 
     @JsonProperty(value = "success")
+    
     success("success"),
 
     @JsonProperty(value = "failure")
+    
     failure("failure"),
 
     @JsonProperty(value = "unclassified")
+    
     unclassified("unclassified"),
 
     @JsonProperty(value = "unknown_default_open_api") @JsonEnumDefaultValue
+    
     unknown_default_open_api("unknown_default_open_api");
 
     /**

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -28,15 +28,19 @@ import com.fasterxml.jackson.annotation.JsonProperty
 enum class StringEnumRef(val value: kotlin.String) {
 
     @JsonProperty(value = "success")
+    
     success("success"),
 
     @JsonProperty(value = "failure")
+    
     failure("failure"),
 
     @JsonProperty(value = "unclassified")
+    
     unclassified("unclassified"),
 
     @JsonProperty(value = "unknown_default_open_api") @JsonEnumDefaultValue
+    
     unknown_default_open_api("unknown_default_open_api");
 
     /**

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
@@ -27,12 +27,15 @@ import com.google.gson.annotations.SerializedName
 enum class ApiStringEnumRef(val value: kotlin.String) {
 
     @SerializedName(value = "success")
+    
     SUCCESS("success"),
 
     @SerializedName(value = "failure")
+    
     FAILURE("failure"),
 
     @SerializedName(value = "unclassified")
+    
     UNCLASSIFIED("unclassified");
 
     /**

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+
 /**
  * An enum with complex-ish naming
  *
@@ -32,13 +33,19 @@ import kotlinx.serialization.encoding.Encoder
 @Serializable(with = PetEnumSerializer::class)
 enum class PetEnum(val value: kotlin.String) {
 
+    
     @SerialName(value = "myFirstValue")
+    
     MY_FIRST_VALUE("myFirstValue"),
 
+    
     @SerialName(value = "MY_SECOND_VALUE")
+    
     MY_SECOND_VALUE("MY_SECOND_VALUE"),
 
+    
     @SerialName(value = "unknown_default_open_api")
+    
     UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
     /**
@@ -81,4 +88,5 @@ internal object PetEnumSerializer : KSerializer<PetEnum> {
         encoder.encodeSerializableValue(kotlin.String.serializer(), value.value)
     }
 }
+
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Following PR https://github.com/OpenAPITools/openapi-generator/pull/21248
Following [this issue](https://github.com/OpenAPITools/openapi-generator/issues/21204), when using integer enums with the kotlin-client generator, the generated enum will serialize and deserialize strings, not integers.

## How to test

1. Create a `test.yml` file with the following content:
```yml
openapi: 3.0.3
info:
  title: Demo
  version: v1

components:
  schemas:
    Code:
      type: integer
      enum:
        - 0
        - 1
    StringCode:
      type: string
      enum:
        - hello
        - world

paths:
  /do:
    get:
      summary: Do something
      responses:
        200:
          description: Successful response
          content:
            application/json:
              schema:
                type: object
                required:
                  - code
                properties:
                  code:
                    $ref: '#/components/schemas/Code'
```
2. Create a `config.json` file to generate only relevant content with the following:
```json
{
  "modelPackage": "com.test",
  "generatorName": "kotlin",
  "enumPropertyNaming": "UPPERCASE",
  "additionalProperties": {
    "serializableModel": true,
    "omitGradleWrapper": true,
    "omitGradlePluginVersions": true
  },
  "globalProperties": {
    "apis": false,
    "models": "",
    "apiDocs": false,
    "modelDocs": false,
    "apiTests": false,
    "modelTests": false
  }
}
```
3. Build openapi on the head branch of this PR: `./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true`
4. Run the builded version against the files you've previously created: `java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i test.yml -g kotlin -o out/ -c config.json`
5. See the generated code handling string enums (`StringCode.kt`) and integer enums (`Code.kt`)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
